### PR TITLE
avoid false targets if it contains `build` directory instead of build…

### DIFF
--- a/base/src/com/google/idea/blaze/base/bazel/BuildSystemProvider.java
+++ b/base/src/com/google/idea/blaze/base/bazel/BuildSystemProvider.java
@@ -127,7 +127,7 @@ public interface BuildSystemProvider {
     FileOperationProvider provider = FileOperationProvider.getInstance();
     for (String filename : possibleBuildFileNames()) {
       File child = new File(directory, filename);
-      if (provider.exists(child)) {
+      if (provider.exists(child) && provider.isFile(child)) {
         return child;
       }
     }


### PR DESCRIPTION
… file